### PR TITLE
Send Validation and Failure Creation

### DIFF
--- a/api/prisma/migrations/20230928162926_failed_request/migration.sql
+++ b/api/prisma/migrations/20230928162926_failed_request/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - The `failure_reason` column on the `BridgeRequest` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "failure_reason" AS ENUM ('REQUEST_NON_EXISTENT', 'REQUEST_INVALID_STATUS', 'REQUEST_SOURCE_ADDRESS_NOT_MATCHING', 'REQUEST_AMOUNT_NOT_MATCHING', 'REQUEST_ASSET_NOT_MATCHING');
+
+-- AlterTable
+ALTER TABLE "BridgeRequest" DROP COLUMN "failure_reason",
+ADD COLUMN     "failure_reason" "failure_reason";
+
+-- CreateTable
+CREATE TABLE "FailedBridgeRequest" (
+    "id" SERIAL NOT NULL,
+    "bridge_request_id" INTEGER,
+    "failure_reason" "failure_reason" NOT NULL,
+
+    CONSTRAINT "FailedBridgeRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "FailedBridgeRequest" ADD CONSTRAINT "FailedBridgeRequest_bridge_request_id_fkey" FOREIGN KEY ("bridge_request_id") REFERENCES "BridgeRequest"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -27,10 +27,19 @@ model BridgeRequest {
   source_chain            Chain                
   destination_chain       Chain                
   status                  BridgeRequestStatus
-  failure_reason          String?
+  failure_reason          FailureReason?
+  failures                FailedBridgeRequest[]
 
   @@index([source_address], map: "index_bridge_request_on_source_address")
   @@index([destination_address], map: "index_bridge_request_on_destination_address")
+
+}
+
+model FailedBridgeRequest {
+  id                      Int                  @id @default(autoincrement())
+  bridge_request_id       Int?
+  bridge_request          BridgeRequest?        @relation(fields: [bridge_request_id], references: [id])
+  failure_reason          FailureReason
 
 }
 
@@ -51,4 +60,14 @@ enum BridgeRequestStatus {
 
 model BridgeHead {
   hash      String   @db.VarChar @unique
+}
+
+
+enum FailureReason {
+  REQUEST_NON_EXISTENT
+  REQUEST_INVALID_STATUS
+  REQUEST_SOURCE_ADDRESS_NOT_MATCHING
+  REQUEST_AMOUNT_NOT_MATCHING
+  REQUEST_ASSET_NOT_MATCHING
+  @@map("failure_reason")
 }

--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -10,7 +10,13 @@ import {
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
-import { BridgeRequestStatus } from '@prisma/client';
+import {
+  BridgeRequest,
+  BridgeRequestStatus,
+  FailureReason,
+} from '@prisma/client';
+import assert from 'assert';
+import { ApiConfigService } from '../api-config/api-config.service';
 import { ApiKeyGuard } from '../auth/guards/api-key.guard';
 import { GraphileWorkerPattern } from '../graphile-worker/enums/graphile-worker-pattern';
 import { GraphileWorkerService } from '../graphile-worker/graphile-worker.service';
@@ -25,7 +31,6 @@ import {
   HeadHash,
   OptionalHeadHash,
 } from './types/dto';
-import { ApiConfigService } from '../api-config/api-config.service';
 
 @Controller('bridge')
 export class BridgeController {
@@ -66,23 +71,23 @@ export class BridgeController {
     { sends }: { sends: BridgeSendRequestDTO[] },
   ): Promise<BridgeSendResponseDTO> {
     const requests = await this.bridgeService.findByIds(sends.map((s) => s.id));
-    const map: BridgeSendResponseDTO = {};
+    const response: BridgeSendResponseDTO = {};
     for (const send of sends) {
       const request = requests.find((r) => r.id === send.id) ?? null;
-      if (!request) {
-        map[send.id] = {
-          status: null,
-          failureReason: 'requested id not found in bridge service',
+
+      const failureReason = this.validateSend(request, send);
+
+      if (failureReason) {
+        response[send.id] = {
+          status: BridgeRequestStatus.FAILED,
+          failureReason,
         };
+        await this.bridgeService.createFailedRequest(request, failureReason);
         continue;
       }
-      if (request.status !== BridgeRequestStatus.CREATED) {
-        map[send.id] = {
-          status: null,
-          failureReason: 'request status is not CREATED',
-        };
-        continue;
-      }
+
+      assert.ok(request);
+
       await this.graphileWorkerService.addJob<MintWIronOptions>(
         GraphileWorkerPattern.MINT_WIRON,
         {
@@ -92,19 +97,20 @@ export class BridgeController {
           destination: request.destination_address,
         },
       );
-      const updated = await this.bridgeService.updateRequest({
+
+      const status = BridgeRequestStatus.PENDING_PRETRANSFER;
+      await this.bridgeService.updateRequest({
         id: request.id,
-        status: BridgeRequestStatus.PENDING_PRETRANSFER,
+        status,
         source_transaction: send.source_transaction ?? undefined,
       });
-      map[send.id] = updated
-        ? { status: updated.status }
-        : {
-            status: null,
-            failureReason: 'not found when attempting to update request',
-          };
+
+      response[send.id] = {
+        status,
+        failureReason: null,
+      };
     }
-    return map;
+    return response;
   }
 
   @UseGuards(ApiKeyGuard)
@@ -150,8 +156,30 @@ export class BridgeController {
   }
 
   @Get('address')
-  async getAddress(): Promise<{ address: string }> {
+  getAddress(): { address: string } {
     const address = this.config.get<string>('IRONFISH_BRIDGE_ADDRESS');
     return { address };
+  }
+
+  validateSend(
+    request: BridgeRequest | null,
+    send: BridgeSendRequestDTO,
+  ): FailureReason | null {
+    if (!request) {
+      return FailureReason.REQUEST_NON_EXISTENT;
+    }
+    if (request.status !== BridgeRequestStatus.CREATED) {
+      return FailureReason.REQUEST_INVALID_STATUS;
+    }
+    if (request.source_address !== send.source_address) {
+      return FailureReason.REQUEST_SOURCE_ADDRESS_NOT_MATCHING;
+    }
+    if (request.asset !== send.asset) {
+      return FailureReason.REQUEST_ASSET_NOT_MATCHING;
+    }
+    if (request.amount !== send.amount) {
+      return FailureReason.REQUEST_AMOUNT_NOT_MATCHING;
+    }
+    return null;
   }
 }

--- a/api/src/bridge/bridge.service.ts
+++ b/api/src/bridge/bridge.service.ts
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable } from '@nestjs/common';
-import { BridgeHead, BridgeRequest, BridgeRequestStatus } from '@prisma/client';
+import {
+  BridgeHead,
+  BridgeRequest,
+  BridgeRequestStatus,
+  FailedBridgeRequest,
+  FailureReason,
+} from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { BridgeDataDTO } from './types/dto';
 
@@ -58,5 +64,20 @@ export class BridgeService {
 
   async getHead(): Promise<BridgeHead | null> {
     return this.prisma.bridgeHead.findFirst();
+  }
+
+  async createFailedRequest(
+    request: BridgeRequest | null,
+    failure_reason: FailureReason,
+  ): Promise<FailedBridgeRequest> {
+    const bridge_request = request
+      ? { connect: { id: request.id } }
+      : undefined;
+    return this.prisma.failedBridgeRequest.create({
+      data: {
+        bridge_request,
+        failure_reason,
+      },
+    });
   }
 }

--- a/api/src/bridge/types/dto.ts
+++ b/api/src/bridge/types/dto.ts
@@ -26,14 +26,19 @@ export type BridgeRetrieveDTO = {
 
 export type BridgeSendRequestDTO = {
   id: AddressFk;
+  amount: string;
+  asset: string;
+  source_address: Address;
   source_transaction: string;
 };
 
+export type BridgeSendItemDTO = {
+  status: BridgeRequestStatus | null;
+  failureReason: string | null;
+};
+
 export type BridgeSendResponseDTO = {
-  [keyof: AddressFk]: {
-    status: BridgeRequestStatus | null;
-    failureReason?: string;
-  };
+  [keyof: AddressFk]: BridgeSendItemDTO;
 };
 
 export type BridgeCreateDTO = { [keyof: Address]: AddressFk };

--- a/api/src/test/mocks.ts
+++ b/api/src/test/mocks.ts
@@ -11,6 +11,7 @@ export const bridgeRequestDTO = (options: {
   destination_address?: string;
   source_address?: string;
   amount?: string;
+  status?: BridgeRequestStatus;
 }): BridgeDataDTO => ({
   amount: options.amount ?? '100',
   source_address: options.source_address ?? '0x0000000',
@@ -19,7 +20,7 @@ export const bridgeRequestDTO = (options: {
     '00000000000000021a63de16fea25d79f66f092862a893274690000000000000',
   destination_address: options.destination_address ?? 'foooooooooooo',
   destination_transaction: null,
-  status: BridgeRequestStatus.CREATED,
+  status: options.status ?? BridgeRequestStatus.CREATED,
   source_chain: Chain.ETHEREUM,
   destination_chain: Chain.IRONFISH,
 });


### PR DESCRIPTION
## Summary
- Validates the data sent in `bridge/send`, if incorrect, skips minting and returns a failure for that request.
- If failure occurs, saves a new `FailedBridgeRequest` entry that is linked to the originating bridge request.
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
