### PR TITLE
adds /bridge/confirm endpoint

### DIFF
--- a/api/src/bridge/types/dto.ts
+++ b/api/src/bridge/types/dto.ts
@@ -46,3 +46,12 @@ export type BridgeCreateDTO = { [keyof: Address]: AddressFk };
 export type HeadHash = { hash: string };
 
 export type OptionalHeadHash = { hash: string | null };
+
+export type BridgeConfirmRequestDTO = {
+  id: AddressFk;
+  destination_transaction: string;
+};
+
+export type BridgeConfirmResponseDTO = {
+  [keyof: AddressFk]: { status: BridgeRequestStatus | null };
+};


### PR DESCRIPTION
## Summary

adds an endpoint to receive information on confirmed send transactions on the Iron Fish chain

requires a 'destination_transaction' hash paired with the request id

updates bridge request status from 'PENDING_ON_DESTINATION_CHAIN' to 'CONFIRMED'

the relay service will hit this endpoint when it finds confirmed transactions that release IRON to end users

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
