### PR TITLE
chore(bridge-api): Fix Jest warnings

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -28,8 +28,7 @@
   ],
   "exclude": [
     "build",
-    "node_modules",
-    "src/**/*.spec.*"
+    "node_modules"
   ],
 }
 


### PR DESCRIPTION
## Summary

Jest functions / types are not recognized. Include the test files in compilation

## Testing Plan

Looked at vs code

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
