### PR TITLE
removes 'wiron' from bridge endpoint names

### DIFF
--- a/api/src/bridge/__snapshots__/bridge.controller.spec.ts.snap
+++ b/api/src/bridge/__snapshots__/bridge.controller.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BridgeController GET /bridge/next_wiron_requests with a missing api key returns a 401 1`] = `
+exports[`BridgeController GET /bridge/next_release_requests with a missing api key returns a 401 1`] = `
 Object {
   "message": "Unauthorized",
   "statusCode": 401,

--- a/api/src/bridge/bridge.controller.spec.ts
+++ b/api/src/bridge/bridge.controller.spec.ts
@@ -19,7 +19,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { bridgeRequestDTO } from '../test/mocks';
 import { bootstrapTestApp } from '../test/test-app';
 import { BridgeService } from './bridge.service';
-import { BridgeSendRequestDTO, UpdateWIronRequestDTO } from './types/dto';
+import { BridgeSendRequestDTO, UpdateRequestDTO } from './types/dto';
 
 describe('BridgeController', () => {
   let app: INestApplication;
@@ -157,18 +157,18 @@ describe('BridgeController', () => {
     });
   });
 
-  describe('GET /bridge/next_wiron_requests', () => {
+  describe('GET /bridge/next_release_requests', () => {
     describe('with a missing api key', () => {
       it('returns a 401', async () => {
         const { body } = await request(app.getHttpServer())
-          .get('/bridge/next_wiron_requests')
+          .get('/bridge/next_release_requests')
           .expect(HttpStatus.UNAUTHORIZED);
 
         expect(body).toMatchSnapshot();
       });
     });
 
-    describe('when multiple wiron bridge requests are requested', () => {
+    describe('when multiple release bridge requests are requested', () => {
       it('returns the records', async () => {
         const mockData = [
           {
@@ -209,11 +209,11 @@ describe('BridgeController', () => {
           },
         ];
         jest
-          .spyOn(bridgeService, 'nextWIronBridgeRequests')
+          .spyOn(bridgeService, 'nextReleaseBridgeRequests')
           .mockResolvedValueOnce(mockData);
 
         const { body } = await request(app.getHttpServer())
-          .get('/bridge/next_wiron_requests')
+          .get('/bridge/next_release_requests')
           .set('Authorization', `Bearer ${API_KEY}`)
           .query({ count: 2 })
           .expect(HttpStatus.OK);
@@ -249,10 +249,10 @@ describe('BridgeController', () => {
     });
   });
 
-  describe('POST /bridge/update_wiron_requests', () => {
+  describe('POST /bridge/update_requests', () => {
     describe('failure cases', () => {
       it('nonexistent request id fails', async () => {
-        const transaction: UpdateWIronRequestDTO = {
+        const transaction: UpdateRequestDTO = {
           id: 123132132,
           destination_transaction: '123123',
           status:
@@ -260,7 +260,7 @@ describe('BridgeController', () => {
         };
 
         const response = await request(app.getHttpServer())
-          .post('/bridge/update_wiron_requests')
+          .post('/bridge/update_requests')
           .set('Authorization', `Bearer ${API_KEY}`)
           .send({
             transactions: [transaction],
@@ -286,14 +286,14 @@ describe('BridgeController', () => {
           },
         ]);
 
-        const transaction: UpdateWIronRequestDTO = {
+        const transaction: UpdateRequestDTO = {
           id: bridgeRequest[0].id,
           destination_transaction: dto.destination_transaction || '123123',
           status: BridgeRequestStatus.PENDING_ON_DESTINATION_CHAIN,
         };
 
         const response = await request(app.getHttpServer())
-          .post('/bridge/update_wiron_requests')
+          .post('/bridge/update_requests')
           .set('Authorization', `Bearer ${API_KEY}`)
           .send({
             transactions: [transaction],

--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -26,10 +26,10 @@ import {
   BridgeSendResponseDTO,
   HeadHash,
   OptionalHeadHash,
-  UpdateWIronRequestDTO,
-  UpdateWIronResponseDTO,
+  UpdateRequestDTO,
+  UpdateResponseDTO,
 } from './types/dto';
-import { NextWIronBridgeRequestsDto } from './types/next-wiron-bridge-requests.dto';
+import { NextBridgeRequestsDto } from './types/next-bridge-requests.dto';
 
 @Controller('bridge')
 export class BridgeController {
@@ -141,20 +141,20 @@ export class BridgeController {
   }
 
   @UseGuards(ApiKeyGuard)
-  @Post('update_wiron_requests')
-  async updateWIronBridgeRequests(
+  @Post('update_requests')
+  async updateBridgeRequests(
     @Body(
       new ValidationPipe({
         errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         transform: true,
       }),
     )
-    { transactions }: { transactions: UpdateWIronRequestDTO[] },
-  ): Promise<UpdateWIronResponseDTO> {
+    { transactions }: { transactions: UpdateRequestDTO[] },
+  ): Promise<UpdateResponseDTO> {
     const requests = await this.bridgeService.findByIds(
       transactions.map((t) => t.id),
     );
-    const response: UpdateWIronResponseDTO = {};
+    const response: UpdateResponseDTO = {};
     for (const transaction of transactions) {
       const request = requests.find((r) => r.id === transaction.id) ?? null;
 
@@ -174,20 +174,20 @@ export class BridgeController {
     return response;
   }
 
-  @Get('next_wiron_requests')
+  @Get('next_release_requests')
   @UseGuards(ApiKeyGuard)
-  async nextWIronBridgeRequests(
+  async nextReleaseBridgeRequests(
     @Query(
       new ValidationPipe({
         errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         transform: true,
       }),
     )
-    { count }: NextWIronBridgeRequestsDto,
+    { count }: NextBridgeRequestsDto,
   ): Promise<List<BridgeRequest>> {
     return {
       object: 'list',
-      data: await this.bridgeService.nextWIronBridgeRequests(count),
+      data: await this.bridgeService.nextReleaseBridgeRequests(count),
     };
   }
 }

--- a/api/src/bridge/bridge.service.spec.ts
+++ b/api/src/bridge/bridge.service.spec.ts
@@ -23,7 +23,7 @@ describe('BridgeService', () => {
     await app.close();
   });
 
-  describe('nextWIronBridgeRequests', () => {
+  describe('nextReleaseBridgeRequests', () => {
     describe('when the amount of running BridgeRequests is greater than or equal to requested number', () => {
       it('returns the running BridgeRequests', async () => {
         const runningBridgeRequest1 = {
@@ -69,7 +69,7 @@ describe('BridgeService', () => {
             runningBridgeRequest2,
           ]);
 
-        expect(await bridgeService.nextWIronBridgeRequests(2)).toMatchObject([
+        expect(await bridgeService.nextReleaseBridgeRequests(2)).toMatchObject([
           runningBridgeRequest1,
           runningBridgeRequest2,
         ]);
@@ -137,7 +137,7 @@ describe('BridgeService', () => {
           .mockResolvedValueOnce([runningBridgeRequest1, runningBridgeRequest2])
           .mockResolvedValueOnce([pendingBridgeRequest]);
 
-        expect(await bridgeService.nextWIronBridgeRequests(3)).toMatchObject([
+        expect(await bridgeService.nextReleaseBridgeRequests(3)).toMatchObject([
           runningBridgeRequest1,
           runningBridgeRequest2,
         ]);

--- a/api/src/bridge/bridge.service.ts
+++ b/api/src/bridge/bridge.service.ts
@@ -131,7 +131,7 @@ export class BridgeService {
     });
   }
 
-  async nextWIronBridgeRequests(count?: number): Promise<BridgeRequest[]> {
+  async nextReleaseBridgeRequests(count?: number): Promise<BridgeRequest[]> {
     return this.prisma.bridgeRequest.findMany({
       where: {
         source_chain: 'ETHEREUM',

--- a/api/src/bridge/types/dto.ts
+++ b/api/src/bridge/types/dto.ts
@@ -50,12 +50,12 @@ export type HeadHash = { hash: string };
 
 export type OptionalHeadHash = { hash: string | null };
 
-export type UpdateWIronRequestDTO = {
+export type UpdateRequestDTO = {
   id: AddressFk;
   destination_transaction: string;
   status: BridgeRequestStatus;
 };
 
-export type UpdateWIronResponseDTO = {
+export type UpdateResponseDTO = {
   [keyof: AddressFk]: { status: BridgeRequestStatus | null };
 };

--- a/api/src/bridge/types/next-bridge-requests.dto.ts
+++ b/api/src/bridge/types/next-bridge-requests.dto.ts
@@ -4,7 +4,7 @@
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
 
-export class NextWIronBridgeRequestsDto {
+export class NextBridgeRequestsDto {
   @Max(Number.MAX_SAFE_INTEGER)
   @Min(1)
   @IsOptional()


### PR DESCRIPTION
## Summary

removing 'wiron' moves toward generalizing endpoints for bridging other assets

renames 'next_wiron_requests' to 'next_release_requests'

renames 'update_wiron_requests' to 'update_requests'

renames associated DTOs and updates tests

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
