### PR TITLE
adds next_burn_requests endpoint

### DIFF
--- a/api/src/bridge/bridge.controller.spec.ts
+++ b/api/src/bridge/bridge.controller.spec.ts
@@ -288,6 +288,100 @@ describe('BridgeController', () => {
     });
   });
 
+  describe('GET /bridge/next_burn_requests', () => {
+    describe('with a missing api key', () => {
+      it('returns a 401', async () => {
+        const { body } = await request(app.getHttpServer())
+          .get('/bridge/next_release_requests')
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(body).toMatchSnapshot();
+      });
+    });
+
+    describe('when multiple burn requests are requested', () => {
+      it('returns the records', async () => {
+        const mockData = [
+          {
+            id: 0,
+            amount: '0',
+            asset: 'IRON',
+            source_address: 'source',
+            destination_address: 'destination',
+            source_transaction: 'source_transaction0',
+            destination_transaction: null,
+            source_burn_transaction: null,
+            source_chain: Chain.IRONFISH,
+            destination_chain: Chain.ETHEREUM,
+            status:
+              BridgeRequestStatus.PENDING_SOURCE_BURN_TRANSACTION_CREATION,
+            failure_reason: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+            started_at: new Date(),
+            completed_at: null,
+          },
+          {
+            id: 1,
+            amount: '1',
+            asset: 'IRON',
+            source_address: 'source',
+            destination_address: 'destination',
+            source_transaction: 'source_transaction',
+            destination_transaction: null,
+            source_burn_transaction: null,
+            source_chain: Chain.ETHEREUM,
+            destination_chain: Chain.IRONFISH,
+            status:
+              BridgeRequestStatus.PENDING_SOURCE_BURN_TRANSACTION_CREATION,
+            failure_reason: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+            started_at: new Date(),
+            completed_at: null,
+          },
+        ];
+        jest
+          .spyOn(bridgeService, 'nextBurnBridgeRequests')
+          .mockResolvedValueOnce(mockData);
+
+        const { body } = await request(app.getHttpServer())
+          .get('/bridge/next_burn_requests')
+          .set('Authorization', `Bearer ${API_KEY}`)
+          .query({ count: 2 })
+          .expect(HttpStatus.OK);
+
+        const { data } = body;
+        expect(data as unknown[]).toMatchObject([
+          {
+            id: mockData[0].id,
+            amount: mockData[0].amount,
+            asset: mockData[0].asset,
+            source_address: mockData[0].source_address,
+            destination_address: mockData[0].destination_address,
+            source_transaction: mockData[0].source_transaction,
+            destination_transaction: mockData[0].destination_transaction,
+            source_chain: mockData[0].source_chain,
+            destination_chain: mockData[0].destination_chain,
+            status: mockData[0].status,
+          },
+          {
+            id: mockData[1].id,
+            amount: mockData[1].amount,
+            asset: mockData[1].asset,
+            source_address: mockData[1].source_address,
+            destination_address: mockData[1].destination_address,
+            source_transaction: mockData[1].source_transaction,
+            destination_transaction: mockData[1].destination_transaction,
+            source_chain: mockData[1].source_chain,
+            destination_chain: mockData[1].destination_chain,
+            status: mockData[1].status,
+          },
+        ]);
+      });
+    });
+  });
+
   describe('POST /bridge/update_requests', () => {
     describe('failure cases', () => {
       it('nonexistent request id fails', async () => {

--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -209,6 +209,23 @@ export class BridgeController {
     };
   }
 
+  @Get('next_burn_requests')
+  @UseGuards(ApiKeyGuard)
+  async nextBurnBridgeRequests(
+    @Query(
+      new ValidationPipe({
+        errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        transform: true,
+      }),
+    )
+    { count }: NextBridgeRequestsDto,
+  ): Promise<List<BridgeRequest>> {
+    return {
+      object: 'list',
+      data: await this.bridgeService.nextBurnBridgeRequests(count),
+    };
+  }
+
   private async upsertBridgeSendRequestDTOs(
     payloads: BridgeSendRequestDTO[],
     status: BridgeRequestStatus,

--- a/api/src/bridge/bridge.service.ts
+++ b/api/src/bridge/bridge.service.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import {
   BridgeRequest,
   BridgeRequestStatus,
+  Chain,
   FailedBridgeRequest,
   FailureReason,
   IronFishTestnetHead,
@@ -134,10 +135,24 @@ export class BridgeService {
   async nextReleaseBridgeRequests(count?: number): Promise<BridgeRequest[]> {
     return this.prisma.bridgeRequest.findMany({
       where: {
-        source_chain: 'ETHEREUM',
-        destination_chain: 'IRONFISH',
+        source_chain: Chain.ETHEREUM,
+        destination_chain: Chain.IRONFISH,
         status:
           BridgeRequestStatus.PENDING_DESTINATION_RELEASE_TRANSACTION_CREATION,
+      },
+      orderBy: {
+        created_at: Prisma.SortOrder.asc,
+      },
+      take: count ?? 1,
+    });
+  }
+
+  async nextBurnBridgeRequests(count?: number): Promise<BridgeRequest[]> {
+    return this.prisma.bridgeRequest.findMany({
+      where: {
+        source_chain: Chain.IRONFISH,
+        destination_chain: Chain.ETHEREUM,
+        status: BridgeRequestStatus.PENDING_SOURCE_BURN_TRANSACTION_CREATION,
       },
       orderBy: {
         created_at: Prisma.SortOrder.asc,


### PR DESCRIPTION
## Summary

next_burn_requests provides the same functionaility as next_release_requests but returns the next requests to burn custom assets on the Iron Fish chain

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
