### PR TITLE
changes burn endpoint to use pending burn creation status

### DIFF
--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -98,7 +98,7 @@ export class BridgeController {
   ): Promise<BridgeSendResponseDTO> {
     const response = await this.upsertBridgeSendRequestDTOs(
       burns,
-      BridgeRequestStatus.PENDING_SOURCE_BURN_TRANSACTION_CONFIRMATION,
+      BridgeRequestStatus.PENDING_SOURCE_BURN_TRANSACTION_CREATION,
     );
     return response;
   }


### PR DESCRIPTION
## Summary

the Iron Fish relay service will hit the 'bridge/burn' endpoint, then the release service will query records with status
'PENDING_SOURCE_BURN_TRANSACTION_CREATION' to know which assets to burn in the next transaction

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
