### PR TITLE
update_requests takes optional transactions

### DIFF
--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -182,9 +182,7 @@ export class BridgeController {
       }
 
       await this.bridgeService.updateRequest({
-        id: transaction.id,
-        status: transaction.status,
-        destination_transaction: transaction.destination_transaction,
+        ...transaction,
       });
 
       response[transaction.id] = { status: transaction.status };

--- a/api/src/bridge/types/dto.ts
+++ b/api/src/bridge/types/dto.ts
@@ -52,8 +52,9 @@ export type OptionalHeadHash = { hash: string | null };
 
 export type UpdateRequestDTO = {
   id: AddressFk;
-  destination_transaction: string;
   status: BridgeRequestStatus;
+  destination_transaction?: string;
+  source_burn_transaction?: string;
 };
 
 export type UpdateResponseDTO = {


### PR DESCRIPTION
## Summary

makes 'destination_transaction' optional in data submitted to the 'bridge/update_requests' endpoint and adds an optional 'source_burn_transaction' field

supports using update_requests for updating status after creating burn transactions

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
