### PR TITLE
feat: update retrieve endpoint to be filterable by chain/status

### DIFF
--- a/api/src/bridge/bridge.controller.spec.ts
+++ b/api/src/bridge/bridge.controller.spec.ts
@@ -60,25 +60,25 @@ describe('BridgeController', () => {
   });
 
   describe('POST /bridge/retrieve', () => {
-    describe('when data is requested by id', () => {
-      it('is successfully returns if fk is in db, null if not', async () => {
-        const unsavedId = 1234567;
-        const requestData = bridgeRequestDTO({});
-        const foo = await prisma.bridgeRequest.create({
-          data: requestData,
-        });
-        const { body } = await request(app.getHttpServer())
-          .post('/bridge/retrieve')
-          .set('Authorization', `Bearer ${API_KEY}`)
-          .send({ ids: [foo.id, unsavedId] })
-          .expect(HttpStatus.OK);
+    it('successfully returns requests', async () => {
+      const unsavedId = 1234567;
+      const requestData = bridgeRequestDTO({
+        source_chain: Chain.ETHEREUM,
+        destination_chain: Chain.IRONFISH,
+        status:
+          BridgeRequestStatus.PENDING_SOURCE_BURN_TRANSACTION_CONFIRMATION,
+      });
+      const foo = await prisma.bridgeRequest.create({
+        data: requestData,
+      });
+      const { body } = await request(app.getHttpServer())
+        .post('/bridge/retrieve')
+        .set('Authorization', `Bearer ${API_KEY}`)
+        .send({ ids: [foo.id, unsavedId] })
+        .expect(HttpStatus.OK);
 
-        expect(body).toMatchObject({
-          [foo.id]: {
-            ...requestData,
-          },
-          [unsavedId]: null,
-        });
+      expect(body).toMatchObject({
+        requests: [requestData],
       });
     });
   });

--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -28,6 +28,7 @@ import { MintWIronOptions } from '../wiron/interfaces/mint-wiron-options';
 import { BridgeService } from './bridge.service';
 import {
   BridgeRetrieveDTO,
+  BridgeRetrieveRequest,
   BridgeSendRequestDTO,
   BridgeSendResponseDTO,
   HeadHash,
@@ -55,14 +56,15 @@ export class BridgeController {
         transform: true,
       }),
     )
-    { ids }: { ids: number[] },
+    req: BridgeRetrieveRequest,
   ): Promise<BridgeRetrieveDTO> {
-    const requests = await this.bridgeService.findByIds(ids);
-    const map: BridgeRetrieveDTO = {};
-    for (const id of ids) {
-      map[id] = requests.find((r) => r.id === id) ?? null;
-    }
-    return map;
+    const where = {
+      source_chain: req.source_chain,
+      destination_chain: req.destination_chain,
+      status: req.status,
+    };
+    const requests = await this.bridgeService.findWhere(where, req.count ?? 1);
+    return { requests };
   }
 
   @UseGuards(ApiKeyGuard)

--- a/api/src/bridge/bridge.service.ts
+++ b/api/src/bridge/bridge.service.ts
@@ -41,6 +41,19 @@ export class BridgeService {
     });
   }
 
+  async findWhere(
+    where: Prisma.BridgeRequestWhereInput,
+    count: number,
+  ): Promise<BridgeRequest[]> {
+    return this.prisma.bridgeRequest.findMany({
+      where,
+      orderBy: {
+        id: Prisma.SortOrder.asc,
+      },
+      take: count,
+    });
+  }
+
   async findBySourceTransaction(
     sourceTransaction: string,
   ): Promise<BridgeRequest | null> {

--- a/api/src/bridge/types/dto.ts
+++ b/api/src/bridge/types/dto.ts
@@ -21,8 +21,15 @@ export type BridgeDataDTO = {
   status: BridgeRequestStatus;
 };
 
+export type BridgeRetrieveRequest = {
+  source_chain?: Chain;
+  destination_chain?: Chain;
+  status?: BridgeRequestStatus;
+  count?: number;
+};
+
 export type BridgeRetrieveDTO = {
-  [keyof: AddressFk]: BridgeDataDTO | null;
+  requests: BridgeDataDTO[];
 };
 
 export type BridgeSendRequestDTO = {

--- a/api/src/test/mocks.ts
+++ b/api/src/test/mocks.ts
@@ -13,6 +13,8 @@ export const bridgeRequestDTO = (options: {
   status?: BridgeRequestStatus;
   source_burn_transaction?: string;
   destination_transaction?: string;
+  source_chain?: Chain;
+  destination_chain?: Chain;
 }): BridgeDataDTO => ({
   amount: options.amount ?? '100',
   source_address: options.source_address ?? '0x0000000',
@@ -22,7 +24,7 @@ export const bridgeRequestDTO = (options: {
   destination_address: options.destination_address ?? '0xfoooooooooooo',
   destination_transaction: options.destination_transaction ?? null,
   status: options.status ?? BridgeRequestStatus.CREATED,
-  source_chain: Chain.ETHEREUM,
-  destination_chain: Chain.IRONFISH,
+  source_chain: options.source_chain ?? Chain.ETHEREUM,
+  destination_chain: options.destination_chain ?? Chain.IRONFISH,
   source_burn_transaction: options.source_burn_transaction ?? null,
 });


### PR DESCRIPTION
## Summary

This endpoint was a remnant of previous design architecture. It is now repurposed so that we can query the open transaction hashes so when the relay is watching it can have a list of transactions to scan for.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
