### PR TITLE
removes default count on retrieve endpoint

### DIFF
--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -63,7 +63,7 @@ export class BridgeController {
       destination_chain: req.destination_chain,
       status: req.status,
     };
-    const requests = await this.bridgeService.findWhere(where, req.count ?? 1);
+    const requests = await this.bridgeService.findWhere(where, req.count);
     return { requests };
   }
 

--- a/api/src/bridge/bridge.service.ts
+++ b/api/src/bridge/bridge.service.ts
@@ -43,7 +43,7 @@ export class BridgeService {
 
   async findWhere(
     where: Prisma.BridgeRequestWhereInput,
-    count: number,
+    count: number | undefined,
   ): Promise<BridgeRequest[]> {
     return this.prisma.bridgeRequest.findMany({
       where,


### PR DESCRIPTION
## Summary

supports returning all matching requests from the retrieve endpoint

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
