### PR TITLE
updates release endpoint to take request ids

### DIFF
--- a/api/src/bridge/types/dto.ts
+++ b/api/src/bridge/types/dto.ts
@@ -67,3 +67,7 @@ export type UpdateRequestDTO = {
 export type UpdateResponseDTO = {
   [keyof: AddressFk]: { status: BridgeRequestStatus | null };
 };
+
+export type ReleaseRequestDTO = {
+  id: AddressFk;
+};


### PR DESCRIPTION
## Summary

for each valid request id the endpoint updates the request status to 'PENDING_DESTINATION_RELEASE_TRANSACTION_CREATION' and enqueues the release graphile job

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
