### PR TITLE
fix parameter naming bug

### DIFF
--- a/api/src/bridge/bridge.controller.ts
+++ b/api/src/bridge/bridge.controller.ts
@@ -145,7 +145,7 @@ export class BridgeController {
       await this.graphileWorkerService.addJob(
         GraphileWorkerPattern.RELEASE_TEST_USDC,
         {
-          bridgeRequest: request.id,
+          bridgeRequestId: request.id,
         },
       );
     }

--- a/api/src/test-usdc/test-usdc.jobs.controller.ts
+++ b/api/src/test-usdc/test-usdc.jobs.controller.ts
@@ -89,10 +89,13 @@ export class TestUsdcJobsController {
     const bridgeRequest = await this.bridgeService.find(
       options.bridgeRequestId,
     );
-    if (!bridgeRequest) {
-      this.logger.error(
-        `No bridge request found for ${options.bridgeRequestId}`,
-        '',
+    if (bridgeRequest === null) {
+      const error = `No bridge request found for ${options.bridgeRequestId}`;
+      this.logger.error(error, '');
+      await this.bridgeService.createFailedRequest(
+        null,
+        FailureReason.REQUEST_INVALID_STATUS,
+        error,
       );
       return { requeue: false };
     }
@@ -101,9 +104,12 @@ export class TestUsdcJobsController {
       bridgeRequest.status !==
       BridgeRequestStatus.PENDING_DESTINATION_RELEASE_TRANSACTION_CREATION
     ) {
-      this.logger.error(
-        `Invalid status for releasing TestUSDC. Bridge request '${options.bridgeRequestId}'`,
-        '',
+      const error = `Invalid status for releasing TestUSDC. Bridge request '${options.bridgeRequestId}'`;
+      this.logger.error(error, '');
+      await this.bridgeService.createFailedRequest(
+        null,
+        FailureReason.REQUEST_INVALID_STATUS,
+        error,
       );
       return { requeue: false };
     }


### PR DESCRIPTION
## Summary
Error was seen in mezmo but it was kind of cryptic, I had to search for the log log "invalid" and I saw this log line:
```
Oct 19 15:40:12 ironfish-bridge-api app[worker] 50 {"level":50,"time":1697755212327,"pid":2,"hostname":"0efbd098-f9e6-410a-affc-abf917c0b76f","error":"","msg":"Invalid status for releasing TestUSDC. Bridge request 'undefined'"}
```
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
