### PR TITLE
uses bridge WebApi implementation in release service

### DIFF
--- a/cli/src/commands/release.ts
+++ b/cli/src/commands/release.ts
@@ -7,12 +7,12 @@ import {
   RawTransactionSerde,
   RpcConnectionError,
   RpcSocketClient,
-  WebApi,
 } from '@ironfish/sdk'
 import { BurnDescription } from '@ironfish/sdk/src/primitives/burnDescription'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
+import { WebApi } from '../webApi'
 
 const MAX_RECIPIENTS_PER_TRANSACTION = 10
 
@@ -26,6 +26,7 @@ export default class Release extends IronfishCommand {
       description: 'API host to sync to',
       parse: (input: string) => Promise.resolve(input.trim()),
       env: 'IRONFISH_API_HOST',
+      required: true,
     }),
     token: Flags.string({
       char: 't',


### PR DESCRIPTION
## Summary

the bridge endpoints won't be a part of the SDK implementation of WebApi

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
