### PR TITLE
renames webApi to bridgeApi

### DIFF
--- a/cli/src/bridgeApi.ts
+++ b/cli/src/bridgeApi.ts
@@ -21,7 +21,7 @@ type BridgeRequest = {
  *  The API should be compatible with the Ironfish Bridge API
  *  https://github.com/iron-fish/ironfish-bridge
  */
-export class WebApi {
+export class BridgeApi {
   host: string
   token: string
 
@@ -36,7 +36,7 @@ export class WebApi {
     this.token = options.token || ''
   }
 
-  async getBridgeHead(): Promise<string | undefined> {
+  async getHead(): Promise<string | undefined> {
     this.requireToken()
 
     const response = await axios
@@ -53,7 +53,7 @@ export class WebApi {
     return response?.data.hash
   }
 
-  async setBridgeHead(head: string): Promise<void> {
+  async setHead(head: string): Promise<void> {
     this.requireToken()
 
     const options = this.options({ 'Content-Type': 'application/json' })
@@ -61,7 +61,7 @@ export class WebApi {
     await axios.post(`${this.host}/bridge/head`, { head }, options)
   }
 
-  async sendBridgeDeposits(
+  async send(
     sends: {
       amount: string
       asset: string
@@ -103,7 +103,7 @@ export class WebApi {
     )
   }
 
-  async getBridgeNextReleaseRequests(
+  async getNextReleaseRequests(
     count?: number,
   ): Promise<{ requests: Array<BridgeRequest> }> {
     this.requireToken()
@@ -120,7 +120,7 @@ export class WebApi {
     return response.data
   }
 
-  async getBridgeNextMintRequests(
+  async getNextMintRequests(
     count?: number,
   ): Promise<{ requests: Array<BridgeRequest> }> {
     this.requireToken()
@@ -138,7 +138,7 @@ export class WebApi {
     return response.data
   }
 
-  async getBridgeNextBurnRequests(
+  async getNextBurnRequests(
     count?: number,
   ): Promise<{ requests: Array<BridgeRequest> }> {
     this.requireToken()
@@ -156,7 +156,7 @@ export class WebApi {
     return response.data
   }
 
-  async getBridgePendingBurnRequests(
+  async getPendingBurnRequests(
     count?: number,
   ): Promise<{ requests: Array<BridgeRequest> }> {
     this.requireToken()
@@ -175,7 +175,7 @@ export class WebApi {
     return response.data
   }
 
-  async updateBridgeRequests(
+  async updateRequests(
     payload: Array<{
       id: number
       status: string

--- a/cli/src/commands/release.ts
+++ b/cli/src/commands/release.ts
@@ -10,9 +10,9 @@ import {
 } from '@ironfish/sdk'
 import { BurnDescription } from '@ironfish/sdk/src/primitives/burnDescription'
 import { Flags } from '@oclif/core'
+import { BridgeApi } from '../bridgeApi'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
-import { WebApi } from '../webApi'
 
 const MAX_RECIPIENTS_PER_TRANSACTION = 10
 
@@ -61,7 +61,7 @@ export default class Release extends IronfishCommand {
       this.exit(1)
     }
 
-    const api = new WebApi({ host: flags.endpoint, token: flags.token })
+    const api = new BridgeApi({ host: flags.endpoint, token: flags.token })
 
     const client = this.sdk.client
 
@@ -83,7 +83,7 @@ export default class Release extends IronfishCommand {
 
   async startSyncing(
     client: RpcSocketClient,
-    api: WebApi,
+    api: BridgeApi,
     account?: string,
   ): Promise<void> {
     const connected = await client.tryConnect()
@@ -125,10 +125,10 @@ export default class Release extends IronfishCommand {
   async processNextReleaseTransaction(
     client: RpcSocketClient,
     account: string,
-    api: WebApi,
+    api: BridgeApi,
   ): Promise<void> {
     const { requests: unprocessedReleaseRequests } =
-      await api.getBridgeNextReleaseRequests(MAX_RECIPIENTS_PER_TRANSACTION)
+      await api.getNextReleaseRequests(MAX_RECIPIENTS_PER_TRANSACTION)
 
     if (unprocessedReleaseRequests.length === 0) {
       this.log('No release requests')
@@ -203,15 +203,15 @@ export default class Release extends IronfishCommand {
       })
     }
 
-    await api.updateBridgeRequests(updatePayload)
+    await api.updateRequests(updatePayload)
   }
 
   async processNextBurnTransaction(
     client: RpcSocketClient,
     account: string,
-    api: WebApi,
+    api: BridgeApi,
   ): Promise<void> {
-    const { requests: nextBurnRequests } = await api.getBridgeNextBurnRequests(
+    const { requests: nextBurnRequests } = await api.getNextBurnRequests(
       MAX_RECIPIENTS_PER_TRANSACTION,
     )
 
@@ -292,17 +292,15 @@ export default class Release extends IronfishCommand {
       })
     }
 
-    await api.updateBridgeRequests(updatePayload)
+    await api.updateRequests(updatePayload)
   }
 
   async processNextMintTransaction(
     client: RpcSocketClient,
     account: string,
-    api: WebApi,
+    api: BridgeApi,
   ): Promise<void> {
-    const { requests: nextMintRequests } = await api.getBridgeNextMintRequests(
-      1,
-    )
+    const { requests: nextMintRequests } = await api.getNextMintRequests(1)
     if (nextMintRequests.length === 0) {
       this.log('No mint requests')
       return
@@ -348,7 +346,7 @@ export default class Release extends IronfishCommand {
         transaction: ${mintTransactionResponse.content.hash}`,
     )
 
-    await api.updateBridgeRequests([
+    await api.updateRequests([
       {
         id: mintRequest.id,
         status: 'PENDING_DESTINATION_MINT_TRANSACTION_CONFIRMATION',


### PR DESCRIPTION
## Summary

renames api implementation for bridge api to avoid confusion and collision with the WebApi from the SDK

renames api methods, removing 'bridge' to avoid redundancy

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
