### PR TITLE
foces remote RPC connection in relay

### DIFF
--- a/cli/src/commands/relay.ts
+++ b/cli/src/commands/relay.ts
@@ -97,7 +97,7 @@ export default class BridgeRelay extends IronfishCommand {
     head?: string,
   ): Promise<void> {
     this.log('Connecting to node...')
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectRpc(false, true)
 
     this.log('Watching with incoming view key:', incomingViewKey)
     this.log('Watching with outgoing view key:', outgoingViewKey)


### PR DESCRIPTION
## Summary

by default, the sdk will fall through to a local RPC client if it fails to connect to a remote node

the relay service should always connect to a remote node

## Testing Plan

manual testing: relay hangs if it's unable to connect since it tries syncing transactions from its own local in-memory rpc client

after changes, relay stops with connection issue

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
