### PR TITLE
updates relay service for node rpc changes

### DIFF
--- a/cli/src/commands/relay.ts
+++ b/cli/src/commands/relay.ts
@@ -115,6 +115,7 @@ export default class BridgeRelay extends IronfishCommand {
       incomingViewKey,
       outgoingViewKey,
       head,
+      memoAsHex: true,
     })
 
     const speed = new Meter()
@@ -216,7 +217,7 @@ export default class BridgeRelay extends IronfishCommand {
             status: 'CONFIRMED',
           })
         } else {
-          const ethAddress = this.decodeEthAddress(note.memoHex)
+          const ethAddress = this.decodeEthAddress(note.memo)
 
           if (!isAddress(ethAddress)) {
             this.log(


### PR DESCRIPTION
## Summary

the 'chain/getTransactionStream' implementation is a bit different from the changes we used on the 'bridge-prototype' branch: requests take an optional 'memoAsHex' parameter and returns the memo field as hex if set instead of returning a separate 'memoHex' field

updates the relay service to use the new request parameter and the memo field

resolves IFL-1800

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
