### PR TITLE
fixes handling of request id memos

### DIFF
--- a/cli/src/commands/relay.ts
+++ b/cli/src/commands/relay.ts
@@ -202,7 +202,9 @@ export default class BridgeRelay extends IronfishCommand {
         }
 
         if (note.sender === bridgeAddress) {
-          const requestId = Number(note.memo)
+          const requestId = Number(
+            Buffer.from(note.memo, 'hex').toString('utf8'),
+          )
 
           if (isNaN(requestId)) {
             continue


### PR DESCRIPTION
## Summary

we still use utf8 encoded memos to store bridge request ids. these need to be converted from hex to utf8 before parsing into numbers

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
