### PR TITLE
confirms burns using public burn data

### DIFF
--- a/api/src/bridge/bridge.service.ts
+++ b/api/src/bridge/bridge.service.ts
@@ -63,6 +63,16 @@ export class BridgeService {
     });
   }
 
+  async findBySourceBurnTransaction(
+    sourceBurnTransaction: string,
+  ): Promise<BridgeRequest[]> {
+    return this.prisma.bridgeRequest.findMany({
+      where: {
+        source_burn_transaction: sourceBurnTransaction,
+      },
+    });
+  }
+
   async upsertRequests(
     requests: BridgeDataDTO[],
     client?: BasePrismaClient,

--- a/api/src/bridge/types/dto.ts
+++ b/api/src/bridge/types/dto.ts
@@ -69,5 +69,5 @@ export type UpdateResponseDTO = {
 };
 
 export type ReleaseRequestDTO = {
-  id: AddressFk;
+  source_burn_transaction: string;
 };

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,7 @@
     "lint": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/",
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "lint:deprecated": "yarn lint --rule \"deprecation/deprecation: warn\"",
-    "start:dev": "yarn build && yarn start:js",
+    "start:dev": "yarn build && yarn start",
     "start": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run",
     "postpack": "rimraf oclif.manifest.json",
     "clean": "rimraf build",

--- a/cli/src/bridgeApi.ts
+++ b/cli/src/bridgeApi.ts
@@ -93,7 +93,9 @@ export class BridgeApi {
     await axios.post(`${this.host}/bridge/burn`, { burns }, this.options())
   }
 
-  async bridgeRelease(releases: { id: number }[]): Promise<void> {
+  async bridgeRelease(
+    releases: { source_burn_transaction: string }[],
+  ): Promise<void> {
     this.requireToken()
 
     await axios.post(
@@ -153,25 +155,6 @@ export class BridgeApi {
       },
       this.options(),
     )
-    return response.data
-  }
-
-  async getPendingBurnRequests(
-    count?: number,
-  ): Promise<{ requests: Array<BridgeRequest> }> {
-    this.requireToken()
-
-    const response = await axios.post<{ requests: Array<BridgeRequest> }>(
-      `${this.host}/bridge/retrieve`,
-      {
-        source_chain: 'IRONFISH',
-        destination_chain: 'ETHEREUM',
-        status: 'PENDING_SOURCE_BURN_TRANSACTION_CONFIRMATION',
-        count,
-      },
-      this.options(),
-    )
-
     return response.data
   }
 


### PR DESCRIPTION
## Summary

the asset ID and amount burned in each burn are public on Iron Fish

we can leverage the public burns fields from transactions that the 'chain/getTransactionStream' RPC returns to identify transactions that burned assets that the bridge controls

- updates '/bridge/release' api endpoint to take a 'source_burn_transaction' instead of a request id
- a single source_burn_transaction might burn assets for multiple bridge requests, so api executes release logic for each matching request

- updates relay service to use public burn data instead of querying api for pending burn transaction hashes

## Testing Plan

ran relay service on devnet to identify burn transactions

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
