### PR TITLE
chore: adds rpc.auth to "node" module, adds terraform vars 

### DIFF
--- a/terraform/modules/node/deployment/docker-compose.yml.tpl
+++ b/terraform/modules/node/deployment/docker-compose.yml.tpl
@@ -12,6 +12,7 @@ services:
       %{if command == "start" && network_id != -1}--networkId ${network_id}%{endif}
       %{if command == "start" && node_name != ""}-n ${node_name}%{endif}
       %{if command == "start"}%{if listen_port != 0}-p ${listen_port}%{else}--no-listen%{endif}%{endif}
+      %{if rpc_auth_token != ""}--rpc.auth=${rpc_auth_token}%{endif}
       %{if rpc_port != 0}--rpc.tcp %{if rpc_host != ""}--rpc.tcp.host=${rpc_host}%{endif} --rpc.tcp.port=${rpc_port}%{endif}
     ports:
       %{if listen_port != 0}- "${listen_port}:${listen_port}"%{endif}

--- a/terraform/regions/ca-central-1/main.tf
+++ b/terraform/regions/ca-central-1/main.tf
@@ -29,14 +29,15 @@ module "node" {
   aws_route53_zone                  = module.aws.route53_zone_ironfish
   aws_subnet_private                = module.aws.subnet_ironfish_private
   aws_vpc                           = module.aws.vpc_ironfish
+  bootstrap_node                    = var.bootstrap_node
+  network_id                        = var.network_id
   environment_name                  = var.node_name
   node_name                         = var.node_name
   instance_type                     = var.node_instance_type
   rpc_allowed_cidr_blocks           = var.rpc_allowed_cidr_blocks
   rpc_auth_token                    = var.rpc_auth_token
-  network_id                        = 1
   instance_connect_cidrs            = [var.ec2_instance_connect_cidr]
-
+  command                           = var.node_command
 }
 
 

--- a/terraform/regions/ca-central-1/variables.tf
+++ b/terraform/regions/ca-central-1/variables.tf
@@ -16,10 +16,6 @@ variable "relay_instance_type" {
   default = "t3.small"
 }
 
-variable "release_instance_type" {
-  default = "t3.small"
-}
-
 variable "node_instance_type" {
   default = "t3.small"
 }
@@ -59,16 +55,24 @@ variable "node_name" {
   default = "ironfish-bridge-node"
 }
 
-variable "release_name" {
-  default = "ironfish-bridge-release"
-}
-
 variable "relay_name" {
   default = "ironfish-bridge-relay"
 }
 
+variable "node_command" {
+  default = "start"
+}
 
+variable "bootstrap_node" {
+  default = {
+    override = false
+    value = ""
+  }
+}
 
+variable "network_id" {
+  default = 1
+}
 
 # API ENV variables
 


### PR DESCRIPTION

## Summary
Vars added in root region for bootstrap etc

## Testing Plan
`terraform apply`, `terraform destroy`, checked logs
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
