### PR TITLE
fix: remove catch statement for bridge/head

### DIFF
--- a/cli/src/bridgeApi.ts
+++ b/cli/src/bridgeApi.ts
@@ -39,16 +39,10 @@ export class BridgeApi {
   async getHead(): Promise<string | undefined> {
     this.requireToken()
 
-    const response = await axios
-      .get<{ hash: string }>(`${this.host}/bridge/head`, this.options())
-      .catch((e) => {
-        // The API returns 404 for no head
-        if (IsAxiosError(e) && e.response?.status === 404) {
-          return null
-        }
-
-        throw e
-      })
+    const response = await axios.get<{ hash: string }>(
+      `${this.host}/bridge/head`,
+      this.options(),
+    )
 
     return response?.data.hash
   }


### PR DESCRIPTION
## Summary

We want to fail if the API can't be reached

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
