### PR TITLE
fixes decoding of numeric request ids in note memo

### DIFF
--- a/cli/src/commands/relay.ts
+++ b/cli/src/commands/relay.ts
@@ -4,6 +4,7 @@
 import { Asset, isValidPublicAddress } from '@ironfish/rust-nodejs'
 import {
   Assert,
+  BufferUtils,
   GetTransactionStreamResponse,
   Meter,
   PromiseUtils,
@@ -201,7 +202,7 @@ export default class BridgeRelay extends IronfishCommand {
 
         if (note.sender === bridgeAddress) {
           const requestId = Number(
-            Buffer.from(note.memo, 'hex').toString('utf8'),
+            BufferUtils.toHuman(Buffer.from(note.memo, 'hex')),
           )
 
           if (isNaN(requestId)) {


### PR DESCRIPTION
## Summary

uses BufferUtils.toHuman to recover the memo string correctly

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
