### PR TITLE
Fix CLI oclif settings

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -51,9 +51,9 @@
     "macos": {
       "identifier": "network.ironfish.bridge.cli"
     },
-    "commands": "./build/src/commands",
+    "commands": "./build/cli/src/commands",
     "hooks": {
-      "init": "./build/src/hooks/version"
+      "init": "./build/cli/src/hooks/version"
     },
     "plugins": [
       "@oclif/plugin-help",


### PR DESCRIPTION
## Summary

Fixed the NPM scripts setup error in CLI project:

```text
$ yarn start:dev deposit
yarn run v1.22.21
$ yarn build && yarn start deposit
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run deposit
 ›   Warning: deposit is not a ironfish-bridge-cli command.
Did you mean help? [y/n]: n
 ›   Error: Run ironfish-bridge-cli help for a list of available commands.
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
cli (master)$ yarn start:dev deposit
```